### PR TITLE
Update to NixOS 24.11

### DIFF
--- a/.github/workflows/generate-proxmox-lxc.yml
+++ b/.github/workflows/generate-proxmox-lxc.yml
@@ -1,4 +1,4 @@
-name: 'generate-proxmox-lxc'
+name: "generate-proxmox-lxc"
 
 # Controls when the workflow will run
 on:
@@ -23,18 +23,18 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-      
+
       - name: Install nix
         uses: cachix/install-nix-action@v24
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_path: nixpkgs=channel:nixos-24.05
+          nix_path: nixpkgs=channel:nixos-24.11
 
       - name: Add dogebox channel
         run: |
           nix-channel --add https://github.com/dogeorg/dogebox-nur-packages/archive/main.tar.gz dogebox
           nix-channel --update
-                    
+
       - name: Generate LXC image
         run: |
           NIX_PATH=$NIX_PATH:$(ls -d /nix/store/*dogebox/) nix run github:nix-community/nixos-generators -- -f proxmox-lxc -c nix/pve.nix | {

--- a/.github/workflows/generate-virtualbox-ova.yml
+++ b/.github/workflows/generate-virtualbox-ova.yml
@@ -1,4 +1,4 @@
-name: 'generate-virtualbox-ova'
+name: "generate-virtualbox-ova"
 
 # Controls when the workflow will run
 on:
@@ -23,18 +23,18 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-      
+
       - name: Install nix
         uses: cachix/install-nix-action@v24
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_path: nixpkgs=channel:nixos-24.05
+          nix_path: nixpkgs=channel:nixos-24.11
 
       - name: Add dogebox channel
         run: |
           nix-channel --add https://github.com/dogeorg/dogebox-nur-packages/archive/main.tar.gz dogebox
           nix-channel --update
-                    
+
       - name: Generate LXC image
         run: |
           NIX_PATH=$NIX_PATH:$(ls -d /nix/store/*dogebox/) nix run github:nix-community/nixos-generators -- -f virtualbox -c nix/vbox.nix | {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixlib": {
       "locked": {
-        "lastModified": 1728781282,
-        "narHash": "sha256-hUP9oxmnOmNnKcDOf5Y55HQ+NnoT0+bLWHLQWLLw9Ks=",
+        "lastModified": 1733015484,
+        "narHash": "sha256-qiyO0GrTvbp869U4VGX5GhAZ00fSiPXszvosY1AgKQ8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "16340f605f4e8e5cf07fd74dcbe692eee2d4f51b",
+        "rev": "0e4fdd4a0ab733276b6d2274ff84ae353f17129e",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728867876,
-        "narHash": "sha256-NCyOA8WZNoojmXH+kBDrQj3LwvakYNzSc0h+LTXkmPE=",
+        "lastModified": 1733101779,
+        "narHash": "sha256-Qqnfnb/RFxBbD25UYJ/yibvl9kIZNK5WkyLsUcb2byk=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "fdf142111597f6c6283cf5ffe092b6293a3911d0",
+        "rev": "a471acc460d4c238936a5116c8cc48a3c431dd66",
         "type": "github"
       },
       "original": {
@@ -38,16 +38,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728909085,
-        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
+        "lastModified": 1733120037,
+        "narHash": "sha256-En+gSoVJ3iQKPDU1FHrR6zIxSLXKjzKY+pnh9tt+Yts=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
+        "rev": "f9f0d5c5380be0a599b1fb54641fa99af8281539",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.05";
+    nixpkgs.url = "nixpkgs/nixos-24.11";
     nixos-generators = {
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/dbx/base.nix
+++ b/nix/dbx/base.nix
@@ -40,6 +40,6 @@
     wget
   ];
 
-  # DO NOT CHANGE THIS. EVER. EVEN WHEN UPDATING YOUR SYSTEM PAST 24.05.
-  system.stateVersion = "24.05";
+  # DO NOT CHANGE THIS. EVER. EVEN WHEN UPDATING YOUR SYSTEM PAST 24.11.
+  system.stateVersion = "24.11";
 }

--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -54,7 +54,7 @@ in\
         export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
         export PATH=$PATH:${pkgs.git}/bin
         echo "Adding nixpkgs channel..."
-        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs
+        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
         echo "Adding dogebox nix channel..."
         ${pkgs.nix}/bin/nix-channel --add https://github.com/dogeorg/dogebox-nur-packages/archive/${dbxRelease}.tar.gz dogebox
         echo "Sleeping for 5 seconds..."


### PR DESCRIPTION
With nixpkgs 24.11 [now released](https://nixos.org/blog/announcements/2024/nixos-2411/), 24.05 is deprecated and will stop getting updates in 30d. 