### PR TITLE
Add avahi daemon to publish mdns record for dogebox.local

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,6 +25,6 @@ Now, it should look like:
 dev=1 nix build .#iso-aarch64 --impure
 ```
 
-The `--impure` flag tells nix to allow reading environment variables, and the `dev=1` env var actually tells our build process to use the `dev.json` file as input overrides for all our servies.
+The `--impure` flag tells nix to allow reading environment variables, and the `dev=1` env var actually tells our build process to use the `dev.json` file as input overrides for all our services.
 
 A couple of our projects that use Golang may need to be explicitly "vendored" to support this workflow. If this is the case, cd to the project directory and run `go mod vendor`. The created `vendor` folder should **not** be committed, and should be added to the `.gitignore` file of the project if it doesn't already exist.

--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -77,13 +77,13 @@
     screen
   ];
 
+  networking.hostName = "dogebox"; # Initial hostName for the box to respond to dogebox.local for first boot and installation steps.
   services.avahi = {
       nssmdns4 = true;
       nssmdns6 = true;
 
       enable = true;
       reflector = true;
-      hostName = "dogebox";
       publish = {
         enable = true;
         addresses = true;

--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -77,7 +77,9 @@
     screen
   ];
 
-  networking.hostName = "dogebox"; # Initial hostName for the box to respond to dogebox.local for first boot and installation steps.
+  # Initial hostName for the box to respond to dogebox.local for first boot and installation steps.
+  # Will be replaced ny dogeboxd configuration
+  networking.hostName = lib.mkDefault ("dogebox");
   services.avahi = {
       nssmdns4 = true;
       nssmdns6 = true;

--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -70,14 +70,30 @@
     };
 
   environment.systemPackages = with pkgs; [
+    avahi
     cloud-utils
     parted
     wpa_supplicant
     screen
   ];
 
+  services.avahi = {
+      nssmdns4 = true;
+      nssmdns6 = true;
+
+      enable = true;
+      reflector = true;
+      hostName = "dogebox";
+      publish = {
+        enable = true;
+        addresses = true;
+        workstation = true;
+        userServices = true;
+      };
+  };
+
   systemd.services.resizerootfs = {
-    description = "Expands root filesystem of boot deviceon first boot";
+    description = "Expands root filesystem of boot device on first boot";
     unitConfig = {
       type = "oneshot";
       after = [ "sysinit.target" ];

--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -64,7 +64,7 @@ in\
         export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
         export PATH=$PATH:${pkgs.git}/bin
         echo "Adding nixpkgs channel..."
-        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
+        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.11-small nixpkgs
         echo "Adding dogebox nix channel..."
         ${pkgs.nix}/bin/nix-channel --add https://github.com/dogeorg/dogebox-nur-packages/archive/${dbxRelease}.tar.gz dogebox
         echo "Sleeping for 5 seconds..."
@@ -121,7 +121,6 @@ in\
     pkgs.nixos-rebuild
     pkgs.bash
     pkgs.nix
-    pkgs.nixos-rebuild
     pkgs.git
   ];
 }

--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -64,7 +64,7 @@ in\
         export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
         export PATH=$PATH:${pkgs.git}/bin
         echo "Adding nixpkgs channel..."
-        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.11-small nixpkgs
+        ${pkgs.nix}/bin/nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
         echo "Adding dogebox nix channel..."
         ${pkgs.nix}/bin/nix-channel --add https://github.com/dogeorg/dogebox-nur-packages/archive/${dbxRelease}.tar.gz dogebox
         echo "Sleeping for 5 seconds..."

--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -118,9 +118,9 @@ in\
 
   # These are all needed for the oneshot boot process above.
   environment.systemPackages = [
-    pkgs.nixos-rebuild
     pkgs.bash
     pkgs.nix
+    pkgs.nixos-rebuild
     pkgs.git
   ];
 }


### PR DESCRIPTION
This should enable us to serve a self-signed cert for https connections as well as making it easier for users to initially connect to the dogebox without having a keyboard and monitor available.

References https://github.com/dogeorg/dogeboxd/issues/84