### PR TITLE
add wirelesstools to dogebox base

### DIFF
--- a/nix/dbx/base.nix
+++ b/nix/dbx/base.nix
@@ -38,6 +38,7 @@
     git
     vim
     wget
+    wirelesstools
   ];
 
   # DO NOT CHANGE THIS. EVER. EVEN WHEN UPDATING YOUR SYSTEM PAST 24.11.


### PR DESCRIPTION
This should be enough for us to get `iwlist` in out path to run through `_dbxroot`