### PR TITLE
wifi networking setup on dogebox hardware

### DIFF
--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -73,7 +73,6 @@
     avahi
     cloud-utils
     parted
-    wpa_supplicant
     screen
   ];
 

--- a/nix/builders/qemu/base.nix
+++ b/nix/builders/qemu/base.nix
@@ -1,4 +1,4 @@
-{ modulesPath, ... }:
+{ pkgs ? import <nixpkgs> {}, lib, modulesPath, ... }:
 
 {
   imports = [
@@ -22,4 +22,8 @@
   boot.loader.grub.device = "/dev/sda";
 
   services.qemuGuest.enable = true;
+
+  # Support for usb wifi dongle for wifi bring-up testing
+  boot.kernelModules = [ "rtw88_8822ce" "rtw_8822bu" "rtw88_pci" "rtw88_core" ];
+  hardware.enableRedistributableFirmware = true;
 }

--- a/nix/dbx/base.nix
+++ b/nix/dbx/base.nix
@@ -39,7 +39,11 @@
     vim
     wget
     wirelesstools
+    networkmanager
   ];
+
+  networking.networkmanager.enable = true;
+  networking.networkmanager.wifi.backend = "iwd";
 
   # DO NOT CHANGE THIS. EVER. EVEN WHEN UPDATING YOUR SYSTEM PAST 24.11.
   system.stateVersion = "24.11";

--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -13,7 +13,7 @@
 
   users.users.shibe = {
     isNormalUser = true;
-    extraGroups = [ "wheel" "dogebox" ];
+    extraGroups = [ "wheel" "dogebox" "networkmanager" ];
 
     # Very temporary, until we have SSH key management in dpanel.
     password = "suchpass";
@@ -22,8 +22,9 @@
   security.sudo.wheelNeedsPassword = false;
 
   # These will be overridden by the included dogebox.nix file above, but set defaults.
-  networking.wireless.enable = lib.mkForce false;
-  networking.networkmanager.enable = lib.mkForce false;
+  networking.wireless.iwd.enable = lib.mkDefault true;
+  networking.networkmanager.enable = lib.mkDefault true;
+  networking.networkmanager.wifi.backend = lib.mkDefault "iwd";
 
   networking.firewall.enable = true;
 
@@ -122,5 +123,6 @@ in\
     pkgs.nix
     pkgs.nixos-rebuild
     pkgs.git
+    pkgs.wirelesstools
   ];
 }


### PR DESCRIPTION
nix configuration to allow dogeboxd to run iwlist to list available networks.

Using `iwd` for Wi-Fi management as it is allegedly better than wpa_supplicant.

`wirelesstools` are needed for `iwlist` to show up.