### PR TITLE
disable PasswordAuthentication

### DIFF
--- a/nix/dbx/dogebox.nix
+++ b/nix/dbx/dogebox.nix
@@ -26,6 +26,7 @@ in
     password = "suchpass";
   };
 
+  # Disable password auth by default for remote (ssh) connections, this won't effect local logins.
   services.openssh.settings.PasswordAuthentication = false;
 
   security.sudo.wheelNeedsPassword = false;


### PR DESCRIPTION
So PasswordAuthentication will be disabled by default if sshd is enabled.