### PR TITLE
fix: Built ISO names are wrong

### DIFF
--- a/nix/builders/iso/builder.nix
+++ b/nix/builders/iso/builder.nix
@@ -1,11 +1,12 @@
 {
+  lib,
   arch,
   dbxRelease,
   ...
 }:
 
 {
-  isoImage.isoName = "dogebox-${dbxRelease}-${arch}.iso";
+  image.baseName = lib.mkForce "dogebox-${dbxRelease}-${arch}";
   isoImage.prependToMenuLabel = "DogeboxOS (";
   isoImage.appendToMenuLabel = ")";
 }


### PR DESCRIPTION
Using `image.baseName` to override the default iso naming scheme