### PR TITLE
Upgrade OS Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,9 +51,8 @@ rec {
       ...
     }@inputs:
     let
-      envDbxRelease = builtins.getEnv "DBX_RELEASE";
-      defaultDbxRelease = "v0.9.0-rc.4";
-      dbxRelease = if envDbxRelease != "" then envDbxRelease else defaultDbxRelease;
+      dbxRelease = "v0.9.0-rc.4";
+      upgradeFlakeDir = builtins.getEnv "DBX_UPGRADE_FLAKE_DIR";
 
       builderBases = {
         iso = ./nix/builders/iso/base.nix;
@@ -68,13 +67,13 @@ rec {
       isOSDeveloperMode = builtins.pathExists "/etc/nixos-dev";
 
       getCopyFlakeScript =
-        system: self:
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        ''
+        nixpkgs.lib.optionalString (upgradeFlakeDir != "") ''
           mkdir -p /etc/nixos
-          ${pkgs.rsync}/bin/rsync -a --delete --exclude='.git' "${self}/" "/etc/nixos/"
+          ${pkgs.rsync}/bin/rsync -a --delete --exclude='.git' "${upgradeFlakeDir}/" "/etc/nixos/"
         '';
 
       getSetOptScript = builderType: isBaseBuilder: ''
@@ -134,7 +133,7 @@ rec {
           (
             { ... }:
             {
-              system.activationScripts.copyFlake = getCopyFlakeScript system self;
+              system.activationScripts.copyFlake = getCopyFlakeScript system;
               system.activationScripts.setOpt = getSetOptScript builderType isBaseBuilder;
               system.activationScripts.versioning = versionScript;
             }

--- a/flake.nix
+++ b/flake.nix
@@ -67,13 +67,14 @@ rec {
       isOSDeveloperMode = builtins.pathExists "/etc/nixos-dev";
 
       getCopyFlakeScript =
-        system:
+        system: self:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          flakeCopySource = if upgradeFlakeDir != "" then upgradeFlakeDir else self;
         in
-        nixpkgs.lib.optionalString (upgradeFlakeDir != "") ''
+        ''
           mkdir -p /etc/nixos
-          ${pkgs.rsync}/bin/rsync -a --delete --exclude='.git' "${upgradeFlakeDir}/" "/etc/nixos/"
+          ${pkgs.rsync}/bin/rsync -a --delete --exclude='.git' "${flakeCopySource}/" "/etc/nixos/"
         '';
 
       getSetOptScript = builderType: isBaseBuilder: ''
@@ -133,7 +134,7 @@ rec {
           (
             { ... }:
             {
-              system.activationScripts.copyFlake = getCopyFlakeScript system;
+              system.activationScripts.copyFlake = getCopyFlakeScript system self;
               system.activationScripts.setOpt = getSetOptScript builderType isBaseBuilder;
               system.activationScripts.versioning = versionScript;
             }


### PR DESCRIPTION
### System upgrades can now copy the temporary OS flake into `/etc/nixos`.

This makes the OS rebuild from a temporary clone of the target release and only replaces `/etc/nixos` during that upgrade flow.

### New features

* Add `DBX_UPGRADE_FLAKE_DIR` support to the OS flake.
* Only run the activation-time flake copy when an upgrade flake directory is provided.
* Rsync the temporary OS flake into `/etc/nixos` while excluding `.git`.
* Restore `dbxRelease` to a fixed release value instead of reading it from `DBX_RELEASE` (Reverts https://github.com/Dogebox-WG/os/pull/83 as allowing the OS flake to be upgraded was the underlying issue, which this fixes).

Related dpanel PR: https://github.com/Dogebox-WG/dogeboxd/pull/216

### Testing helper
Dev tool allowing system upgrade to a specific commit:
https://github.com/Dogebox-WG/dpanel/tree/test/upgrade-os-flake
https://github.com/Dogebox-WG/dogeboxd/tree/test/upgrade-os-flake
While running the above branches, open dev-tools with `ctrl-L`, select `Open Config`, scroll down to `Dev-only override for the OS repo commit/ref used during system update staging` and paste an os repo commit hash into the text box