### PR TITLE
fix(wifi): remove iwd, rely only on wpa_supplicant

### DIFF
--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -69,6 +69,7 @@
     "nvme"
     "usbhid"
   ];
+
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [
     "rtw88_8822ce"
@@ -119,19 +120,19 @@
   # This allows a user to configure the dogebox by only plugging in power
   # Caveat: Upon configuring the OS with a proper Wi-Fi network, the user will
   # have to reconnect to that network and manually reload the dpanel page.
-  networking.wireless.iwd.enable = true;
+  networking.wireless.enable = lib.mkDefault true;
 
   services.create_ap = {
     enable = lib.mkDefault true;
     settings = {
       INTERNET_IFACE = "lo";
-      WIFI_IFACE = "wlan0";
+      WIFI_IFACE = "wlP3p49s0";
       SSID = "Dogebox";
       PASSPHRASE = "SuchPass";
     };
   };
 
-  networking.wireless.interfaces = [ "wlan0" ];
+  networking.wireless.interfaces = [ "wlP3p49s0" ];
 
   systemd.services.resizerootfs = {
     description = "Expands root filesystem of boot device on first boot";

--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -71,6 +71,9 @@
   ];
 
   boot.initrd.kernelModules = [ ];
+  # Load bearing backports in the rtw88 driver
+  # If these are removed, iwlist scan will crash
+  # https://github.com/lwfinger/rtw88/issues/418
   boot.kernelModules = [
     "rtw88_8822ce"
     "rtw88_pci"

--- a/nix/builders/nanopc-t6/base.nix
+++ b/nix/builders/nanopc-t6/base.nix
@@ -71,20 +71,6 @@
   ];
 
   boot.initrd.kernelModules = [ ];
-  # Load bearing backports in the rtw88 driver
-  # If these are removed, iwlist scan will crash
-  # https://github.com/lwfinger/rtw88/issues/418
-  boot.kernelModules = [
-    "rtw88_8822ce"
-    "rtw88_pci"
-    "rtw88_core"
-  ];
-
-  boot.extraModulePackages =
-    let
-      rtw88 = config.boot.kernelPackages.callPackage ./rtw88 { };
-    in
-    [ rtw88 ];
 
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";


### PR DESCRIPTION
`iwd` was causing some grief in specifying the wifi network, meaning it didn't seem to work at all.

This requires an update to dogeboxd as well.