### PR TITLE
Add post-upgrade migration defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,6 @@ rec {
     let
       dbxRelease = "v0.9.0-rc.6";
       upgradeFlakeDir = builtins.getEnv "DBX_UPGRADE_FLAKE_DIR";
-
       builderBases = {
         iso = ./nix/builders/iso/base.nix;
         qemu = ./nix/builders/qemu/base.nix;
@@ -91,9 +90,17 @@ rec {
       '';
 
       versionScript =
+        system:
         let
+          pkgs = nixpkgs.legacyPackages.${system};
           flakeLock = ./flake.lock;
           flakeLockContent = builtins.readFile flakeLock;
+          migrationsJsonContent = builtins.toJSON {
+            "pre_0.9_os_flake" = {
+              runs = 0;
+              doNotRun = true;
+            };
+          };
         in
         ''
           mkdir -p /opt/versioning
@@ -116,6 +123,32 @@ rec {
           mkdir -p /opt/versioning/dpanel
           echo '${inputs.dpanel.rev}' > /opt/versioning/dpanel/rev
           echo '${inputs.dpanel.narHash}' > /opt/versioning/dpanel/hash
+
+          mkdir -p /opt/dogebox
+          migrations_json_path=/opt/dogebox/migrations.json
+          migrations_json_tmp=$(mktemp)
+          if [ -f "$migrations_json_path" ]; then
+            if ${pkgs.jq}/bin/jq '
+              ."pre_0.9_os_flake" = (
+                (."pre_0.9_os_flake" // {})
+                + { "doNotRun": true }
+                + (if ((."pre_0.9_os_flake" // {}) | has("runs")) then {} else { "runs": 0 } end)
+              )
+            ' "$migrations_json_path" > "$migrations_json_tmp"; then
+              :
+            else
+              echo "warning: failed to merge migrations.json, leaving existing file unchanged" >&2
+              rm -f "$migrations_json_tmp"
+              migrations_json_tmp=""
+            fi
+          else
+            printf '%s\n' '${migrationsJsonContent}' > "$migrations_json_tmp"
+          fi
+
+          if [ -n "$migrations_json_tmp" ]; then
+            install -o dogeboxd -g dogebox -m 0640 "$migrations_json_tmp" "$migrations_json_path"
+            rm -f "$migrations_json_tmp"
+          fi
         '';
 
       dbxEntryModule = ./nix/dbx/base.nix;
@@ -136,7 +169,7 @@ rec {
             {
               system.activationScripts.copyFlake = getCopyFlakeScript system self;
               system.activationScripts.setOpt = getSetOptScript builderType isBaseBuilder;
-              system.activationScripts.versioning = versionScript;
+              system.activationScripts.versioning = versionScript system;
             }
           )
         ];
@@ -169,7 +202,7 @@ rec {
           system,
           builderType,
           devMode ? isOSDeveloperMode,
-          devBootloader ? false
+          devBootloader ? false,
         }:
         let
           arch = nixpkgs.lib.strings.removeSuffix "-linux" system;
@@ -193,7 +226,8 @@ rec {
           inherit system format;
           modules = [
             builderSpecificModule
-          ] ++ (mkConfigModules { inherit system builderType isBaseBuilder; });
+          ]
+          ++ (mkConfigModules { inherit system builderType isBaseBuilder; });
           specialArgs = getSpecialArgs arch system builderType devMode devBootloader;
         };
 


### PR DESCRIPTION
- keep new installs opted out of the OS flake migration by creating a pre-filled `migrations.json` file if it doesn't already exist
- prerelease testing can be achieved by editing `migrations.json` manually when needed